### PR TITLE
Update connect-mac.md

### DIFF
--- a/connect-mac.md
+++ b/connect-mac.md
@@ -7,9 +7,9 @@ lastupdated: "2018-10-17"
 {:shortdesc: .shortdesc}
 {:new_window: target="_blank"}
 
-# Connect to SSL VPN – MAC OSX 10x and higher
+# Connect to SSL VPN – macOS
 
-Install the latest version of Mac MotionPro client v1.1.7 from the Apple Store. Be sure to uninstall any previous versions before updating.
+Install the latest version of the MotionPro client from the [Array Networks website](https://support.arraynetworks.net/prx/001/http/supportportal.arraynetworks.net/downloads/downloads.html). Be sure to uninstall any previous versions before updating.
 
 After you install the new client, go to the following directory and launch the VPN using the Terminal application. 
 
@@ -19,4 +19,4 @@ From there, run the following command to get connected to the SSL VPN:
 
 `./vpn_cmdline -h vpn.wdc04.softlayer.com -u username -p password`
 
-A list of VPN End-Points can be found [here](https://www.softlayer.com/vpn-access).
+A list of VPN endpoints can be found [here](https://www.softlayer.com/vpn-access).


### PR DESCRIPTION
- App Store version is out of date, updated to point to Array Networks website for download
- changed spelling and capitalization of "macOS" and "endpoints" to conventional use